### PR TITLE
HTTPS'ed jQuery in /examples

### DIFF
--- a/example/colorize.html
+++ b/example/colorize.html
@@ -25,7 +25,7 @@
       </tbody>
     </table>
 
-    <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+    <script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
     <script src="../filtrex.js"></script>
     <script src="colorize.js"></script>
 

--- a/example/highlight.html
+++ b/example/highlight.html
@@ -24,7 +24,7 @@
       </tbody>
     </table>
 
-    <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+    <script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
     <script src="../filtrex.js"></script>
     <script src="highlight.js"></script>
 

--- a/example/plot.html
+++ b/example/plot.html
@@ -13,8 +13,8 @@
 
     <div class="plot"></div>
 
-    <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.min.js"></script>
+    <script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.min.js"></script>
     <script src="../filtrex.js"></script>
     <script src="plot.js"></script>
 


### PR DESCRIPTION
This fixes the `Blocked mixed content` error in GitHub.com live preview (ie. when you follow the links from README.md).

![image](https://user-images.githubusercontent.com/1671665/39515128-6b2c32fa-4df9-11e8-9bf3-144904ee6b50.png)
