### PR TITLE
Fix security holes

### DIFF
--- a/test/filtrex-test.html
+++ b/test/filtrex-test.html
@@ -158,6 +158,12 @@ tests({
 
         eq(31, evil({'"+(window.p0wned = true)+"': 31}));
         eq(false, window.p0wned);
+
+        eq(42, compileExpression(
+            "'undefined:(window.p0wned=true)));((true?(x=>x)'()",
+            {'undefined:(window.p0wned=true)));((true?(x=>x)': ()=>42}
+        )());
+        eq(false, window.p0wned);
     },
 
     'backslash escaping': function() {

--- a/test/filtrex-test.html
+++ b/test/filtrex-test.html
@@ -148,6 +148,22 @@ tests({
         eq(false, window.p0wned);
     },
 
+    'cannot access properties of the data prototype': function() {
+        eq(undefined, compileExpression('a')(Object.create({a: 42})));
+    },
+
+    'cannot inject single-quoted names with double quotes': function() {
+        window.p0wned = false;
+        let evil = compileExpression(`'"+(window.p0wned = true)+"'`);
+
+        eq(31, evil({'"+(window.p0wned = true)+"': 31}));
+        eq(false, window.p0wned);
+    },
+
+    'backslash escaping': function() {
+        eq('\\good', compileExpression(`"\\" + '\\'`)({'\\':'good'}));
+    },
+
 });
 
 </script>


### PR DESCRIPTION
Fixes #17, fixes #18. Also fixes errors with trailing backslash in strings. Makes expressions only see own properties of the `data` object (ie. you cannot return the `toString` function from an expression).