### PR TITLE
Add ability to override how properties are initialized

### DIFF
--- a/filtrex.js
+++ b/filtrex.js
@@ -8,7 +8,7 @@
  *
  * -Joe Walnes
  */
-function compileExpression(expression, extraFunctions /* optional */) {
+function compileExpression(expression, extraFunctions /* optional */, propMapFcn) {
     var functions = {
         abs: Math.abs,
         ceil: Math.ceil,
@@ -50,8 +50,14 @@ function compileExpression(expression, extraFunctions /* optional */) {
         throw 'Unknown function: ' + funcName + '()';
     }
 
-    function prop(obj, name) {
+    function propDefault(obj, name) {
         return Object.prototype.hasOwnProperty.call(obj||{}, name) ? obj[name] : undefined;
+    }
+
+    function prop(obj, name) {
+      if (propMapFcn)
+        return propMapFcn(obj, name, propDefault);
+      return propDefault(obj, name);
     }
 
     var func = new Function('functions', 'data', 'unknown', 'prop', js.join(''));


### PR DESCRIPTION
I wanted to be able to use text variables names as the actual variable values, and am suggesting the following simple way of doing so - by adding a callback that can replace the `prop` function.

**Example usage:**
This example will return true or false, if the search string matches the input text.

e.g. 
"hi and there and (this or dog)" => returns 1
"hi and black and (this or dog)" => returns 0

```
  var testString = "hi there how are you?\nthis is another day";

  function mapIt(obj, name)
  {
    var result = testString.indexOf(name) != -1;
    return result;
  }

  try {
    var searchFcn = compileExpression(expression, additionalFunctions, mapIt); // <-- Filtrex!
    input.css('background-color', '#dfd');
  } catch (e) {
    // Failed to parse expression. Dont search
    input.css('background-color', '#fdd');
    return;
  }

```