### PR TITLE
Fix #31: Support double quotes in strings

### DIFF
--- a/filtrex.js
+++ b/filtrex.js
@@ -122,12 +122,7 @@ function filtrexParser() {
                   return "SYMBOL";`
                 ], // 'some-symbol'
 
-                ['"(?:[^"])*"',
-                 `yytext = JSON.stringify(
-                     yytext.substr(1, yyleng-2)
-                  );
-                  return "STRING";`
-                ], // "foo"
+                ['"(?:\\\\"|[^"])*"', 'return "STRING";'], // "foo"
 
                 // End
                 ['$', 'return "EOF";'],

--- a/src/filtrex.js
+++ b/src/filtrex.js
@@ -122,12 +122,7 @@ function filtrexParser() {
                   return "SYMBOL";`
                 ], // 'some-symbol'
 
-                ['"(?:[^"])*"',
-                 `yytext = JSON.stringify(
-                     yytext.substr(1, yyleng-2)
-                  );
-                  return "STRING";`
-                ], // "foo"
+                ['"(?:\\\\"|[^"])*"', 'return "STRING";'], // "foo"
 
                 // End
                 ['$', 'return "EOF";'],

--- a/test/filtrex-test.html
+++ b/test/filtrex-test.html
@@ -173,7 +173,8 @@ tests({
     },
 
     'backslash escaping': function() {
-        eq('\\good', compileExpression(`"\\" + '\\'`)({'\\':'good'}));
+        eq('\\good', compileExpression(`"\\\\" + '\\'`)({'\\':'good'}));
+        eq('\\good', compileExpression(`"\\\\" + '\\\\'`)({'\\\\':'good'}));
     },
 
 });

--- a/test/filtrex-test.html
+++ b/test/filtrex-test.html
@@ -177,6 +177,10 @@ tests({
         eq('\\good', compileExpression(`"\\\\" + '\\\\'`)({'\\\\':'good'}));
     },
 
+    'double quotes inside strings': function() {
+        eq('"test"', compileExpression('"\\"test\\""')({}));
+    }
+
 });
 
 </script>


### PR DESCRIPTION
~~This PR makes it possible to use double quotes inside strings, provided they're escaped with a preceding backslash.~~

Please see the updated version here: https://github.com/m93a/filtrex/pull/12