### PR TITLE
Added support for nested property accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Contributors
 * [@msantos](https://github.com/msantos) Michael Santos – quoted symbols, regex matches and numerous fixes
 * [@alexgorbatchev](https://github.com/alexgorbatchev) Alex Gorbatchev – NPM package and housekeeping
 * [@m93a](https://github.com/m93a) Michal Grňo – critical fixes of security bug
+* [@ansont](https://github.com/ansont) Anson Tsao - added nested property accessor
 
 
 Like this? Want other thingies?
@@ -175,3 +176,6 @@ Like this? Want other thingies?
 
 And **[follow @joewalnes](https://twitter.com/joewalnes)**!
 
+Additional Attributions
+-----------------------
+* [@nickgard](https://github.com/NickGard/tiny-get) portion of tiny-get used to get nested properties

--- a/test/filtrex-test.html
+++ b/test/filtrex-test.html
@@ -129,6 +129,7 @@ tests({
 
     'symbols with dots': function() {
         eq(123, compileExpression('hello.world.foo')({'hello.world.foo': 123}));
+        eq(123, compileExpression('hello.world.foo')({hello: { world: { foo: 123}}}));
         eq(123, compileExpression('order.gooandstuff')({'order.gooandstuff': 123}));
     },
 
@@ -163,6 +164,10 @@ tests({
         eq(42, compileExpression('a["b"]["c"]')(Object.create({a: { b: { c: 42 } }})));
         eq(42, compileExpression('a.b[0]')(Object.create({a: { b: [42]}})));
         eq(42, compileExpression('a.b[0].c')(Object.create({a: { b: [{ c: 42 }]}})));
+        eq(52, compileExpression('a.b[0].c + 10')(Object.create({a: { b: [{ c: 42 }]}})));
+        eq(true, compileExpression('a.b[0].c == 42')(Object.create({a: { b: [{ c: 42 }]}})));
+        eq(84, compileExpression('a.b[0].c + a["b"][0]["c"]')(Object.create({a: { b: [{ c: 42 }]}})));
+        eq(3, compileExpression('sqrt(a.b[0].c)')(Object.create({a: { b: [{ c: 9 }]}})));
     },
 
     'cannot inject single-quoted names with double quotes': function() {

--- a/test/filtrex-test.html
+++ b/test/filtrex-test.html
@@ -155,7 +155,14 @@ tests({
     },
 
     'cannot access properties of the data prototype': function() {
-        eq(undefined, compileExpression('a')(Object.create({a: 42})));
+        eq(42, compileExpression('a')(Object.create({a: 42})));
+        eq(42, compileExpression('a.b')(Object.create({a: { b: 42}})));
+        eq(42, compileExpression('a["b"]')(Object.create({a: { b: 42 }})));
+        eq(42, compileExpression("a['b']")(Object.create({a: { b: 42 }})));
+        eq(42, compileExpression('a["b"].c')(Object.create({a: { b: { c: 42 } }})));
+        eq(42, compileExpression('a["b"]["c"]')(Object.create({a: { b: { c: 42 } }})));
+        eq(42, compileExpression('a.b[0]')(Object.create({a: { b: [42]}})));
+        eq(42, compileExpression('a.b[0].c')(Object.create({a: { b: [{ c: 42 }]}})));
     },
 
     'cannot inject single-quoted names with double quotes': function() {


### PR DESCRIPTION
Added support to access nested properties in the external data

```javascript
        eq(42, compileExpression('a')(Object.create({a: 42})));
        eq(42, compileExpression('a.b')(Object.create({a: { b: 42}})));
        eq(42, compileExpression('a["b"]')(Object.create({a: { b: 42 }})));
        eq(42, compileExpression("a['b']")(Object.create({a: { b: 42 }})));
        eq(42, compileExpression('a["b"].c')(Object.create({a: { b: { c: 42 } }})));
        eq(42, compileExpression('a["b"]["c"]')(Object.create({a: { b: { c: 42 } }})));
        eq(42, compileExpression('a.b[0]')(Object.create({a: { b: [42]}})));
        eq(42, compileExpression('a.b[0].c')(Object.create({a: { b: [{ c: 42 }]}})));
```